### PR TITLE
feat: incluir schedules com unidade na rota /professionals

### DIFF
--- a/src/routes/professionals.ts
+++ b/src/routes/professionals.ts
@@ -14,9 +14,24 @@ router.get('/professionals', async (request: Request, response: Response): Promi
         role: 'professional',
         ...(specialty ? { specialty: specialty as string } : {}),
       },
+      include: {
+        schedules: {
+          include: {
+            unit: {
+              include: {
+                address: true, // Inclui endereço completo da unidade
+              },
+            },
+            workHours: true, // Inclui horários de trabalho, se existir como relação
+          },
+        },
+        units: true, // Inclui lista de unidades associadas ao profissional
+      },
     });
 
-    response.json(professionals.map((professional) => omit(professional, ['password'])));
+    response.json(
+      professionals.map((professional) => omit(professional, ['password']))
+    );
   } catch (error) {
     console.error(error);
     response.status(500).json({
@@ -25,65 +40,59 @@ router.get('/professionals', async (request: Request, response: Response): Promi
   }
 });
 
-router.get(
-  '/professionals/:id/recent-patients',
-  async (request: Request, response: Response): Promise<void> => {
-    try {
-      const { id } = request.params;
-      const { days_ago: daysAgo = '15' } = request.query;
+router.get('/professionals/:id/recent-patients', async (request: Request, response: Response): Promise<void> => {
+  try {
+    const { id } = request.params;
+    const { days_ago: daysAgo = '15' } = request.query;
 
-      const professional = await prisma.user.findUnique({
-        where: {
-          id: Number(id),
-          role: 'professional',
-        },
+    const professional = await prisma.user.findUnique({
+      where: {
+        id: Number(id),
+        role: 'professional',
+      },
+    });
+
+    if (!professional) {
+      response.status(404).json({
+        error: 'Não encontramos um profissional com o ID informado, verifique se o mesmo está correto.',
       });
-      if (!professional) {
-        response.status(404).json({
-          error:
-            'Não encontramos um profissional com o ID informado, verifique se o mesmo está correto.',
-        });
-
-        return;
-      }
-
-      const appointments = await prisma.appointment.findMany({
-        where: {
-          status: 'completed',
-          professionalId: Number(id),
-          scheduledFor: {
-            gte: subDays(new Date(), Number(daysAgo)),
-          },
-        },
-        include: {
-          patient: {
-            include: {
-              address: true,
-            },
-          },
-        },
-        orderBy: {
-          scheduledFor: 'desc',
-        },
-        distinct: ['patientId'],
-      });
-
-      response.json(
-        appointments.map((appointment) => {
-          return {
-            ...omit(appointment.patient, ['password']),
-            lastVisit: appointment.scheduledFor,
-          };
-        }),
-      );
-    } catch (error) {
-      console.error(error);
-
-      response.status(500).json({
-        error: 'Não foi possível buscar os pacientes recentes. Por favor, tente mais tarde.',
-      });
+      return;
     }
-  },
-);
+
+    const appointments = await prisma.appointment.findMany({
+      where: {
+        status: 'completed',
+        professionalId: Number(id),
+        scheduledFor: {
+          gte: subDays(new Date(), Number(daysAgo)),
+        },
+      },
+      include: {
+        patient: {
+          include: {
+            address: true,
+          },
+        },
+      },
+      orderBy: {
+        scheduledFor: 'desc',
+      },
+      distinct: ['patientId'],
+    });
+
+    response.json(
+      appointments.map((appointment) => ({
+        ...omit(appointment.patient, ['password']),
+        lastVisit: appointment.scheduledFor,
+      }))
+    );
+  } catch (error) {
+    console.error(error);
+
+    response.status(500).json({
+      error: 'Não foi possível buscar os pacientes recentes. Por favor, tente mais tarde.',
+    });
+  }
+});
 
 export default router;


### PR DESCRIPTION
Alterações realizadas
- Inclusão da relação `schedules` ao buscar profissionais, com:
  - Unidades vinculadas à agenda (`unit`)
  - Endereço completo da unidade (`address`)
  - Horários de trabalho (`workHours`)
